### PR TITLE
エラー出力も文字列として取得できる関数の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@ fmt.Println(string(out))
 // 1
 ```
 
+```go
+out, err := CombinedOutput(
+	[]string{"echo", "1"},
+	[]string{"grep", "2"},
+)
+if err == nil {
+	log.Fatal(err)
+}
+if string(out) != "" {
+	log.Fatal("output is not empty.")
+}
+
+out, _ = CombinedOutput(
+	[]string{"rmdir", "not_exist_dir"},
+)
+fmt.Println(string(out))
+// Output:
+// rmdir: failed to remove 'not_exist_dir': No such file or directory
+```
+
 ## Installation
 
 ```

--- a/README.md
+++ b/README.md
@@ -19,17 +19,6 @@ fmt.Println(string(out))
 ```
 
 ```go
-out, err := CombinedOutput(
-	[]string{"echo", "1"},
-	[]string{"grep", "2"},
-)
-if err == nil {
-	log.Fatal(err)
-}
-if string(out) != "" {
-	log.Fatal("output is not empty.")
-}
-
 out, _ = CombinedOutput(
 	[]string{"rmdir", "not_exist_dir"},
 )

--- a/example_test.go
+++ b/example_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"fmt"
 	"log"
+	"testing"
 )
 
 func ExampleCommandPipeLine() {
@@ -17,4 +18,28 @@ func ExampleCommandPipeLine() {
 	fmt.Println(string(out))
 	// Output:
 	// 1
+}
+
+func TestCombinedOutput(t *testing.T) {
+	out, err := CombinedOutput(
+		[]string{"echo", "1"},
+		[]string{"grep", "2"},
+	)
+	if err == nil {
+		log.Fatal(err)
+	}
+	if string(out) != "" {
+		log.Fatal("output is not empty.")
+	}
+
+	out, err = CombinedOutput(
+		[]string{"echo", "1"},
+		[]string{"rmdir", "tmptmptmp"},
+	)
+	if err == nil {
+		log.Fatal(err)
+	}
+	if string(out) == "" {
+		log.Fatal("output is empty.")
+	}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,6 @@ package pipeline
 import (
 	"fmt"
 	"log"
-	"testing"
 )
 
 func ExampleCommandPipeLine() {
@@ -18,28 +17,4 @@ func ExampleCommandPipeLine() {
 	fmt.Println(string(out))
 	// Output:
 	// 1
-}
-
-func TestCombinedOutput(t *testing.T) {
-	out, err := CombinedOutput(
-		[]string{"echo", "1"},
-		[]string{"grep", "2"},
-	)
-	if err == nil {
-		log.Fatal(err)
-	}
-	if string(out) != "" {
-		log.Fatal("output is not empty.")
-	}
-
-	out, err = CombinedOutput(
-		[]string{"echo", "1"},
-		[]string{"rmdir", "tmptmptmp"},
-	)
-	if err == nil {
-		log.Fatal(err)
-	}
-	if string(out) == "" {
-		log.Fatal("output is empty.")
-	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/jiro4989/go-pipeline

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/jiro4989/go-pipeline
+module github.com/mattn/go-pipeline

--- a/pipeline.go
+++ b/pipeline.go
@@ -34,7 +34,7 @@ func Output(commands ...[]string) ([]byte, error) {
 	return out.Bytes(), nil
 }
 
-// CombinedOutput はエラー出力もbyte文字列として返却する
+// CombinedOutput runs the commands and returns its combined standard output and standard error.
 func CombinedOutput(commands ...[]string) ([]byte, error) {
 	cmds := make([]*exec.Cmd, len(commands))
 	var err error

--- a/pipeline.go
+++ b/pipeline.go
@@ -33,3 +33,32 @@ func Output(commands ...[]string) ([]byte, error) {
 	}
 	return out.Bytes(), nil
 }
+
+// CombinedOutput はエラー出力もbyte文字列として返却する
+func CombinedOutput(commands ...[]string) ([]byte, error) {
+	cmds := make([]*exec.Cmd, len(commands))
+	var err error
+
+	var out bytes.Buffer
+	for i, c := range commands {
+		cmds[i] = exec.Command(c[0], c[1:]...)
+		if i > 0 {
+			if cmds[i].Stdin, err = cmds[i-1].StdoutPipe(); err != nil {
+				return nil, err
+			}
+		}
+		cmds[i].Stderr = &out
+	}
+	cmds[len(cmds)-1].Stdout = &out
+	for _, c := range cmds {
+		if err = c.Start(); err != nil {
+			return out.Bytes(), err
+		}
+	}
+	for _, c := range cmds {
+		if err = c.Wait(); err != nil {
+			return out.Bytes(), err
+		}
+	}
+	return out.Bytes(), nil
+}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -1,0 +1,30 @@
+package pipeline
+
+import (
+	"log"
+	"testing"
+)
+
+func TestCombinedOutput(t *testing.T) {
+	out, err := CombinedOutput(
+		[]string{"echo", "1"},
+		[]string{"grep", "2"},
+	)
+	if err == nil {
+		log.Fatal(err)
+	}
+	if string(out) != "" {
+		log.Fatal("output is not empty.")
+	}
+
+	out, err = CombinedOutput(
+		[]string{"echo", "1"},
+		[]string{"rmdir", "tmptmptmp"},
+	)
+	if err == nil {
+		log.Fatal(err)
+	}
+	if string(out) == "" {
+		log.Fatal("output is empty.")
+	}
+}


### PR DESCRIPTION
os/execパッケージの`CombinedOutput`と同様の
エラー出力もbyteとして取得できる関数を追加しました。

ご確認のほどよろしくお願いいたします。